### PR TITLE
Add support for multiple batadv devices

### DIFF
--- a/announce.py
+++ b/announce.py
@@ -10,12 +10,15 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-d', '--directory', action='store',
                     help='structure directory', required=True)
 
-parser.add_argument('-b', '--batman', action='store',
-                    help='batman-adv device', default='bat0')
+parser.add_argument('-b', '--batman', action='append',
+                    help='batman-adv device')
 
 args = parser.parse_args()
 
+if not args.batman:
+    args.batman = ['bat0']
+
 print(json.dumps(gather_data(
     args.directory,
-    {'batadv_dev': args.batman}
+    {'batadv_ifaces': args.batman}
 )))

--- a/neighbours.d/batadv
+++ b/neighbours.d/batadv
@@ -2,13 +2,19 @@
     open("{}/address".format(path)).read().strip(): {"neighbours": {
         neigh[0]: {"lastseen": neigh[1], "tq": neigh[2]}
         for neigh in neighbours
-        if neigh[3] == path[len('/sys/class/net/{}/lower_'.format(batadv_dev)):]
+        if neigh[3] == import_module('os.path').basename(path)[len('lower_'):]
     }}
     for path in
-    import_module('glob').glob('/sys/class/net/{}/lower_*'.format(batadv_dev))
-})([
-    (line[0], float(line[1].strip('s')), int(line[2].strip(')')), line[4].strip('[]:'))
-    for line in map(lambda l: l.replace('(', '').replace('[', '').split(),
-        open('/sys/kernel/debug/batman_adv/{}/originators'.format(batadv_dev)))
-    if line[0] == line[3]
-])
+    import_module('itertools').chain(*map(
+        lambda batadv_iface : import_module('glob').glob('/sys/class/net/{}/lower_*'.format(batadv_iface)),
+        batadv_ifaces
+    ))
+})(list(import_module('itertools').chain(*map(
+    lambda batadv_iface : [
+        (line[0], float(line[1].strip('s')), int(line[2].strip(')')), line[4].strip('[]:'))
+        for line in map(lambda l: l.replace('(', '').replace('[', '').split(),
+            open('/sys/kernel/debug/batman_adv/{}/originators'.format(batadv_iface)))
+        if line[0] == line[3]
+    ],
+    batadv_ifaces
+))))

--- a/nodeinfo.d/network/addresses
+++ b/nodeinfo.d/network/addresses
@@ -9,9 +9,12 @@
     ]
 )(
     # generate the list of ifaces
-    [ batadv_dev ] +
-    list(map(
-        lambda s: s[len('/sys/class/net/{}/upper_'.format(batadv_dev)):],
-        import_module('glob').glob('/sys/class/net/{}/upper_*'.format(batadv_dev))
-    ))
+    batadv_ifaces +
+    list(frozenset(map(
+        lambda s: import_module('os.path').basename(s)[len('upper_'):],
+        import_module('itertools').chain(*map(
+            lambda batadv_iface : import_module('glob').glob('/sys/class/net/{}/upper_*'.format(batadv_iface)),
+            batadv_ifaces
+        ))
+    )))
 )

--- a/nodeinfo.d/network/mac
+++ b/nodeinfo.d/network/mac
@@ -1,1 +1,1 @@
-open('/sys/class/net/' + batadv_dev + '/address').read().strip()
+open('/sys/class/net/' + batadv_ifaces[0] + '/address').read().strip()

--- a/nodeinfo.d/network/mesh
+++ b/nodeinfo.d/network/mesh
@@ -1,13 +1,14 @@
 {
-    batadv_dev: {
+    batadv_iface: {
         "interfaces": {
             "tunnel": [
                 open('/sys/class/net/{}/address'.format(iface)).read().strip()
                 for iface in map(
                     lambda line: line.split(':')[0],
-                    call(['batctl', '-m', batadv_dev, 'if'])
+                    call(['batctl', '-m', batadv_iface, 'if'])
                 )
             ]
         }
     }
+    for batadv_iface in batadv_ifaces
 }

--- a/nodeinfo.d/network/mesh
+++ b/nodeinfo.d/network/mesh
@@ -7,6 +7,10 @@
                     lambda line: line.split(':')[0],
                     call(['batctl', '-m', batadv_iface, 'if'])
                 )
+            ],
+            "other": [
+                open('/sys/class/net/{}/address'.format(iface)).read().strip()
+                for iface in [batadv_iface]
             ]
         }
     }

--- a/nodeinfo.d/node_id
+++ b/nodeinfo.d/node_id
@@ -1,1 +1,1 @@
-open('/sys/class/net/' + batadv_dev + '/address').read().strip().replace(':', '')
+open('/sys/class/net/' + batadv_ifaces[0] + '/address').read().strip().replace(':', '')

--- a/respondd.py
+++ b/respondd.py
@@ -67,15 +67,18 @@ if __name__ == "__main__":
     parser.add_argument('-d', dest='directory',
                         default='.', metavar='<dir>',
                         help='data provider directory (default: $PWD)')
-    parser.add_argument('-b', dest='batadv_iface',
-                        default='bat0', metavar='<iface>',
+    parser.add_argument('-b', dest='batadv_ifaces',
+                        action='append', metavar='<iface>',
                         help='batman-adv interface (default: bat0)')
     args = parser.parse_args()
+
+    if not args.batadv_ifaces:
+        args.batadv_ifaces = ['bat0']
 
     socketserver.ThreadingUDPServer.address_family = socket.AF_INET6
     server = socketserver.ThreadingUDPServer(
         ("", args.port),
-        get_handler(args.directory, {'batadv_dev': args.batadv_iface})
+        get_handler(args.directory, {'batadv_ifaces': args.batadv_ifaces})
     )
 
     if args.mcast_ifaces:

--- a/statistics.d/traffic
+++ b/statistics.d/traffic
@@ -12,5 +12,13 @@
         'bytes' if key.endswith('_bytes') else 'dropped' if key.endswith('_dropped') else 'packets',
         value
     )
-    for key, value in map(lambda s: list(map(str.strip, s.split(': ', 1))), call(['ethtool', '-S', batadv_dev])[1:])
+    for key, value in (lambda t:
+       dict(set((a, sum(int(y) for x, y in t if x == a)) for a, b in t)).items()
+    )(list(import_module('itertools').chain(*map(
+        lambda batadv_iface :
+            list(map(lambda s:
+                 list(map(str.strip, s.split(': ', 1))),
+                 call(['ethtool', '-S', batadv_iface])[1:])),
+            batadv_ifaces
+    ))))
 ))


### PR DESCRIPTION
A multidomain setup has usually multiple batman-adv interfaces on a single gateway/vpn server. mesh-announce must therefore be able to read the state of all these batman-adv interfaces and report it in the usual format.