### PR TITLE
Work around ThreadingUDPServer thread leak on python 3.7

### DIFF
--- a/respondd.py
+++ b/respondd.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         ("", args.port),
         get_handler(get_providers(args.directory), {'batadv_dev': args.batadv_iface, 'mesh_ipv4': args.mesh_ipv4})
     )
+    server.daemon_threads = True
 
     if args.mcast_ifaces:
         mcast_ifaces = { ifname: group for ifname, group, *_


### PR DESCRIPTION
The ThreadingMixIn class (used byThreadingUDPServer/ThreadingTCPServer/...) server stopped using
daemon_threads by default with Python 3.7. But the releasing of the threads is only done by Threading*Server when the server closes. So in the meantime, all threads are gathered in the server object and thus we "leak" memory over the lifetime of the server.

An attacker can therefore cause an OOM based DOS by just requesting some resources again and again:

    import socket
  
    while True:
        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
        sock.sendto(bytes("GET statistic", "utf-8"), ("127.0.0.1", 1001))
        sock.close()

To work around this, the server can be forced back to use daemon_threads.

An actual fix for this problem has to be integrated by upstream. Like the patches already started in PR https://github.com/python/cpython/pull/13893