### PR TITLE
Add multidomain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,30 @@ ratelimit it on the allowed interfaces for the same reason.
 
 Those are all available options (`respondd --help`):
 
-    respondd.py [-p <port>] [-g <group> -i <if0> [-i <if1> ..]] [-d <dir>]
+```
+      respondd.py -h
+      respondd.py [-p <port>] [-g <group>] [-i [<group>%]<if0>] [-i [<group>%]<if1> ..] [-d <dir>] [-b <batman_iface> ..]
 
-for example:
+optional arguments:
+  -h, --help            show this help message and exit
+  -p <port>             port number to listen on (default 1001)
+  -g <link local group>
+                        link-local multicast group (default ff02::2:1001), set
+                        to emtpy string to disable
+  -s <site local group>
+                        site-local multicast group (default ff05::2:1001), set
+                        to empty string to disable
+  -i <iface>            listening interface (default bat0), may be specified
+                        multiple times
+  -d <dir>              data provider directory (default: $PWD/providers)
+  -b <iface>            batman-adv interface to answer for (default: bat0).
+                        Specify once per domain
+  -m <mesh_ipv4>        mesh ipv4 address
+```
 
-    respondd.py -d /opt/mesh-announce/providers -i <your-clientbridge-if> -i <your-mesh-vpn-if> -b <your-batman-if> -m <mesh ipv4 address>
+This is a possible configuration for a site with a single domain:
+
+    `respondd.py -d /opt/mesh-announce/providers -i <your-clientbridge-if> -i <your-mesh-vpn-if> -b <your-batman-if> -m <mesh ipv4 address>`
 
  * `<your-clientbridge-if>`: interfacename of mesh-bridge (for example br-ffXX)
  * `<your-mesh-vpn-if>`: interfacename of fastd or tuneldigger (for example ffXX-mvpn)
@@ -78,11 +97,16 @@ The ipv4 address can be requested for example by
 [ddhcpd](https://github.com/TobleMiner/gluon-sargon/blob/feature-respondd-gateway-update/ddhcpd/files/usr/sbin/ddhcpd-gateway-update#L3)
 via
 
-    gluon-neighbour-info -p 1001 -d ff02::1 -i bat0 -r gateway
+    `gluon-neighbour-info -p 1001 -d ff02::1 -i bat0 -r gateway`
     
 This will request all json objects for all gateways. The json object for the
 gateway can then be selected by the known macadress. The ip4 is stored in
 `node_id.address.ipv4`.
+
+Configuration for a multi-domain site (domains 'one', 'two' and 'three') might look like this:
+
+    `respondd.py -d /opt/mesh-announce/providers -i meshvpn-one -i br-one -i bat-one -b bat-one -i meshvpn-two -i br-two -i bat-two -b bat-two -i meshvpn-three -i br-three -i bat-three -b bat-three`
+
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Those are all available options (`respondd --help`):
 
 ```
       respondd.py -h
-      respondd.py [-p <port>] [-g <group>] [-i [<group>%]<if0>] [-i [<group>%]<if1> ..] [-d <dir>] [-b <batman_iface> ..]
+      respondd.py [-p <port>] [-g <group>] [-i [<group>%]<if0>] [-i [<group>%]<if1> ..] [-d <dir>] [-b <batman_iface>[:<mesh_ipv4>] ..]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -106,6 +106,11 @@ gateway can then be selected by the known macadress. The ip4 is stored in
 Configuration for a multi-domain site (domains 'one', 'two' and 'three') might look like this:
 
     `respondd.py -d /opt/mesh-announce/providers -i meshvpn-one -i br-one -i bat-one -b bat-one -i meshvpn-two -i br-two -i bat-two -b bat-two -i meshvpn-three -i br-three -i bat-three -b bat-three`
+
+In a more complex configuration involving the distributed DHCP deamon ddhcpd you might want to advertise different ipv4 gateways depending on the domain the query came from.
+This can be realized by adding gateway address overrides to the corresponding batman interfaces:
+
+    `respondd.py -d /opt/mesh-announce/providers -i meshvpn-one -i br-one -i bat-one -b bat-one:10.42.1.1 -i meshvpn-two -i br-two -i bat-two -b bat-two:10.42.2.1 -i meshvpn-three -i br-three -i bat-three -b bat-three:10.42.3.1`
 
 
 ### Debugging

--- a/metasocketserver.py
+++ b/metasocketserver.py
@@ -1,0 +1,38 @@
+import ctypes
+import socket
+from socketserver import ThreadingUDPServer
+
+class in6_addr_U(ctypes.Union):
+    _fields_ = [
+        ('__u6_addr8', ctypes.c_uint8 * 16),
+        ('__u6_addr16', ctypes.c_uint16 * 8),
+        ('__u6_addr32', ctypes.c_uint32 * 4),
+    ]
+
+
+class in6_addr(ctypes.Structure):
+    _fields_ = [
+        ('__in6_u', in6_addr_U),
+    ]
+
+class in6_pktinfo(ctypes.Structure):
+    _fields_ = [
+        ('ipi6_addr', in6_addr),
+        ('ipi6_ifindex', ctypes.c_uint),
+    ]
+
+class MetadataUDPServer(ThreadingUDPServer):
+    def __init__(self, *args, **kwargs):
+        super(MetadataUDPServer, self).__init__(*args, **kwargs)
+        self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_RECVPKTINFO, 1)
+
+    def get_request(self):
+        data, anc_data, _, client_addr = self.socket.recvmsg(self.max_packet_size, socket.CMSG_SPACE(65535))
+        ifindex = None
+        for anc_record in anc_data:
+            (anc_level, anc_type, anc_data) = anc_record
+            if anc_level == socket.IPPROTO_IPV6 and anc_type == socket.IPV6_PKTINFO:
+                pktinfo = in6_pktinfo.from_buffer_copy(anc_data)
+                ifindex = pktinfo.ipi6_ifindex
+        return (data, self.socket, ifindex), client_addr
+

--- a/metasocketserver.py
+++ b/metasocketserver.py
@@ -30,9 +30,9 @@ class MetadataUDPServer(ThreadingUDPServer):
         data, anc_data, _, client_addr = self.socket.recvmsg(self.max_packet_size, socket.CMSG_SPACE(65535))
         ifindex = None
         for anc_record in anc_data:
-            (anc_level, anc_type, anc_data) = anc_record
+            (anc_level, anc_type, anc_datum) = anc_record
             if anc_level == socket.IPPROTO_IPV6 and anc_type == socket.IPV6_PKTINFO:
-                pktinfo = in6_pktinfo.from_buffer_copy(anc_data)
+                pktinfo = in6_pktinfo.from_buffer_copy(anc_datum)
                 ifindex = pktinfo.ipi6_ifindex
         return (data, self.socket, ifindex), client_addr
 

--- a/respondd.py
+++ b/respondd.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import metasocketserver
 import socketserver
 import argparse
 import socket
@@ -9,16 +10,16 @@ import os
 from zlib import compress
 
 from providers import get_providers
+import util
 
-
-def get_handler(providers, env):
+def get_handler(providers, batadv_ifaces, env):
     class ResponddUDPHandler(socketserver.BaseRequestHandler):
-        def multi_request(self, providernames):
+        def multi_request(self, providernames, local_env):
             ret = {}
             for name in providernames:
                 try:
                     provider = providers[name]
-                    ret[provider.name] = provider.call(env)
+                    ret[provider.name] = provider.call(local_env)
                 except:
                     pass
             return compress(str.encode(json.dumps(ret)))[2:-4]
@@ -26,12 +27,20 @@ def get_handler(providers, env):
         def handle(self):
             data = self.request[0].decode('UTF-8').strip()
             socket = self.request[1]
+            ifindex = self.request[2]
             response = None
 
+            batadv_dev = util.ifindex_to_batiface(ifindex, batadv_ifaces)
+            if batadv_dev == None:
+                return
+
+            local_env = dict(env)
+            local_env['batadv_dev'] = batadv_dev
+
             if data.startswith("GET "):
-                response = self.multi_request(data.split(" ")[1:])
+                response = self.multi_request(data.split(" ")[1:], local_env)
             else:
-                answer = providers[data].call(env)
+                answer = providers[data].call(local_env)
                 if answer:
                     response = str.encode(json.dumps(answer))
 
@@ -43,48 +52,55 @@ def get_handler(providers, env):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(usage="""
       %(prog)s -h
-      %(prog)s [-p <port>] [-g <group>] [-i [<group>%]<if0>] [-i [<group>%]<if1> ..] [-d <dir>]""")
+      %(prog)s [-p <port>] [-g <group>] [-i [<group>%%]<if0>] [-i [<group>%%]<if1> ..] [-d <dir>] [-b <batman_iface>""")
     parser.add_argument('-p', dest='port',
                         default=1001, type=int, metavar='<port>',
                         help='port number to listen on (default 1001)')
-    parser.add_argument('-g', dest='group',
-                        default='ff02::2:1001', metavar='<group>',
-                        help='multicast group (default ff02::2:1001)')
+    parser.add_argument('-g', dest='link_group',
+                        default='ff02::2:1001', metavar='<link local group>',
+                        help='link-local multicast group (default ff02::2:1001)')
+    parser.add_argument('-s', dest='site_group',
+                        default='ff05::2:1001', metavar='<site local group>',
+                        help='site-local multicast group (default ff05::2:1001), set to empty string to disable')
     parser.add_argument('-i', dest='mcast_ifaces',
-                        action='append', metavar='<iface>',
-                        help='interface on which the group is joined')
+                        action='append', default=[ 'bat0' ], metavar='<iface>',
+                        help='listening interface (default bat0), may be specified multiple times')
     parser.add_argument('-d', dest='directory',
                         default='./providers', metavar='<dir>',
                         help='data provider directory (default: $PWD/providers)')
-    parser.add_argument('-b', dest='batadv_iface',
-                        default='bat0', metavar='<iface>',
-                        help='batman-adv interface (default: bat0)')
+    parser.add_argument('-b', dest='batadv_ifaces',
+                        action='append', default=[ 'bat0' ], metavar='<iface>',
+                        help='batman-adv interface to answer for (default: bat0). Specify once per domain')
     parser.add_argument('-m', dest='mesh_ipv4',
                         metavar='<mesh_ipv4>',
                         help='mesh ipv4 address')
     args = parser.parse_args()
 
-    socketserver.ThreadingUDPServer.address_family = socket.AF_INET6
-    socketserver.ThreadingUDPServer.allow_reuse_address = True
-    server = socketserver.ThreadingUDPServer(
+    metasocketserver.MetadataUDPServer.address_family = socket.AF_INET6
+    metasocketserver.MetadataUDPServer.allow_reuse_address = True
+    server = metasocketserver.MetadataUDPServer(
         ("", args.port),
-        get_handler(get_providers(args.directory), {'batadv_dev': args.batadv_iface, 'mesh_ipv4': args.mesh_ipv4})
+        get_handler(get_providers(args.directory), args.batadv_ifaces, {'mesh_ipv4': args.mesh_ipv4})
     )
     server.daemon_threads = True
 
-    if args.mcast_ifaces:
-        mcast_ifaces = { ifname: group for ifname, group, *_
-                        in [ reversed([ args.group ] + ifspec.split('%')) for ifspec
-                         in args.mcast_ifaces ] }
+    def join_group(mcast_group, if_index=0):
+        group_bin = socket.inet_pton(socket.AF_INET6, mcast_group)
+        mreq = group_bin + struct.pack('@I', if_index)
+        server.socket.setsockopt(
+            socket.IPPROTO_IPV6,
+            socket.IPV6_JOIN_GROUP,
+            mreq
+        )
 
-        for (inf_id, inf_name) in socket.if_nameindex():
-            if inf_name in mcast_ifaces:
-                group_bin = socket.inet_pton(socket.AF_INET6, mcast_ifaces[inf_name])
-                mreq = group_bin + struct.pack('@I', inf_id)
-                server.socket.setsockopt(
-                    socket.IPPROTO_IPV6,
-                    socket.IPV6_JOIN_GROUP,
-                    mreq
-                )
+    mcast_ifaces = { ifname: group for ifname, group, *_
+                    in [ reversed([ args.link_group ] + ifspec.split('%')) for ifspec
+                     in args.mcast_ifaces ] }
+
+    for (if_index, if_name) in socket.if_nameindex():
+        if if_name in mcast_ifaces:
+            join_group(mcast_ifaces[if_name], if_index)
+            if len(args.site_group) > 0:
+                join_group(args.site_group, if_index)
 
     server.serve_forever()

--- a/respondd.py
+++ b/respondd.py
@@ -52,7 +52,7 @@ def get_handler(providers, batadv_ifaces, env):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(usage="""
       %(prog)s -h
-      %(prog)s [-p <port>] [-g <group>] [-i [<group>%%]<if0>] [-i [<group>%%]<if1> ..] [-d <dir>] [-b <batman_iface>""")
+      %(prog)s [-p <port>] [-g <group>] [-i [<group>%%]<if0>] [-i [<group>%%]<if1> ..] [-d <dir>] [-b <batman_iface> ..]""")
     parser.add_argument('-p', dest='port',
                         default=1001, type=int, metavar='<port>',
                         help='port number to listen on (default 1001)')

--- a/util.py
+++ b/util.py
@@ -34,16 +34,26 @@ def ifindex_to_iface(if_index):
             return iface
     return None
 
+
 def iface_match_recursive(iface, candidates):
+    """Check if iface has any connection with an interface from candidates
+       through master/slave relationship and return the name of the first
+       interface found to have a master/slave relation with it or None if
+       there is no relation with any of the interfaces
+    """
+    # Search up the interface tree, check master of iface
     if os.path.exists('/sys/class/net/' + iface + '/master'):
         master = os.path.basename(os.readlink('/sys/class/net/' + iface + '/master'))
         res = iface_match_recursive(master, candidates)
         if res != None:
             return res
 
+    # Search down the interface tree
     for ciface in candidates:
+        # Check current interface
         if ciface == iface:
             return iface
+        # Check master of every candidate interface
         if os.path.exists('/sys/class/net/' + ciface + '/master'):
             master = os.path.basename(os.readlink('/sys/class/net/' + ciface + '/master'))
             res = iface_match_recursive(iface, [ master ])
@@ -53,6 +63,11 @@ def iface_match_recursive(iface, candidates):
     return None
 
 def ifindex_to_batiface(if_index, batman_ifaces):
+    """Check if the interace with interface index if_index is connected to a
+       batman interface in batman_ifaces and return the name of the batman
+       interface it is connected with or None if it is not connected to any
+       of the specified interfaces
+    """
     iface = ifindex_to_iface(if_index)
     if iface in batman_ifaces or iface == None:
         return iface

--- a/util.py
+++ b/util.py
@@ -26,3 +26,27 @@ def find_modules(base, *path):
         path_files.append((lpath, files))
     return path_files
 
+def ifindex_to_iface(if_index):
+    ifaces = next(os.walk('/sys/class/net'))[1]
+    for iface in ifaces:
+        index = open('/sys/class/net/' + iface + '/ifindex').read()
+        if int(index) == if_index:
+            return iface
+    return None
+
+def iface_match_recursive(iface, candidates):
+    for ciface in candidates:
+      if ciface == iface:
+        return iface
+      if os.path.exists('/sys/class/net/' + ciface + '/master'):
+        master = os.path.basename(os.readlink('/sys/class/net/' + ciface + '/master'))
+        res = iface_match_recursive(iface, [ master ])
+        if res != None:
+          return ciface;
+    return None
+
+def ifindex_to_batiface(if_index, batman_ifaces):
+    iface = ifindex_to_iface(if_index)
+    if iface in batman_ifaces or iface == None:
+        return iface
+    return iface_match_recursive(iface, batman_ifaces)

--- a/util.py
+++ b/util.py
@@ -35,14 +35,21 @@ def ifindex_to_iface(if_index):
     return None
 
 def iface_match_recursive(iface, candidates):
-    for ciface in candidates:
-      if ciface == iface:
-        return iface
-      if os.path.exists('/sys/class/net/' + ciface + '/master'):
-        master = os.path.basename(os.readlink('/sys/class/net/' + ciface + '/master'))
-        res = iface_match_recursive(iface, [ master ])
+    if os.path.exists('/sys/class/net/' + iface + '/master'):
+        master = os.path.basename(os.readlink('/sys/class/net/' + iface + '/master'))
+        res = iface_match_recursive(master, candidates)
         if res != None:
-          return ciface;
+            return res
+
+    for ciface in candidates:
+        if ciface == iface:
+            return iface
+        if os.path.exists('/sys/class/net/' + ciface + '/master'):
+            master = os.path.basename(os.readlink('/sys/class/net/' + ciface + '/master'))
+            res = iface_match_recursive(iface, [ master ])
+            if res != None:
+                return ciface
+
     return None
 
 def ifindex_to_batiface(if_index, batman_ifaces):


### PR DESCRIPTION
This PR adds true multidomain support. This enables support for site-local multicast groups and thus completes support for Gluon 2019. Commandline options are fully backwards compatible with current master.

To use mesh-announce in a multidomain environment with domains 'one', 'two' and 'three' and the batman-interfaces 'bat-one', 'bat-two' and 'bat-three' run mesh-announce with the following parameters:

`mesh-announce -d plugins -i bat-one -b bat-one -i bat-two -b bat-two -i bat-three -b bat-three`

mesh-announce will automatically detect the origin domain of requests and answer with data for the correct domain.