### PR TITLE
If possible use systemd's machine-id as node_id

### DIFF
--- a/providers/nodeinfo/node_id.py
+++ b/providers/nodeinfo/node_id.py
@@ -6,4 +6,7 @@ class Source(providers.DataSource):
         return ['batadv_dev']
 
     def call(self, batadv_dev):
-        return open('/sys/class/net/' + batadv_dev + '/address').read().strip().replace(':', '')
+        try:
+            return open('/etc/machine-id').read().strip()[:12]
+        except:
+            return open('/sys/class/net/' + batadv_dev + '/address').read().strip().replace(':', '')


### PR DESCRIPTION
If available use systemd's machine-id as node_id.
Fixes #37 and, for non babel setups, the necessity of having fixed MAC addresses on the bat interfaces.