### PR TITLE
[FEATURE] Add Provider for domain_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ information needed for example to display the name of the server on node-maps.
     systemctl start respondd
     systemctl status respondd
 
-     
+
 ## Upgrade
 
     cp /opt/mesh-announce/respondd.service /etc/systemd/system/
@@ -81,6 +81,7 @@ optional arguments:
   -b <iface>            batman-adv interface to answer for (default: bat0).
                         Specify once per domain
   -m <mesh_ipv4>        mesh ipv4 address
+  -n <domain_code>      Gateway domain_code for nodeinfo/system/domain_code
 ```
 
 This is a possible configuration for a site with a single domain:
@@ -92,7 +93,8 @@ This is a possible configuration for a site with a single domain:
  * `<your-batman-if>`: B.A.T.M.A.N interfacename (usually bat-ffXX)
  * `<mesh ipv4 address>`: The ipv4 address of this gateway (usually the ip on interface `<your-clientbridge-if>`)  
     you can get the ip with `ip a s dev br-ffXX|grep inet|head -n1|cut -d" " -f 6|sed 's|/.*||g'`
-    
+ * `<domain_code>`: The internal domain_code, identical with the gluon domain_name
+
 The ipv4 address can be requested for example by
 [ddhcpd](https://github.com/TobleMiner/gluon-sargon/blob/feature-respondd-gateway-update/ddhcpd/files/usr/sbin/ddhcpd-gateway-update#L3)
 via

--- a/providers/nodeinfo/system/domain_code.py
+++ b/providers/nodeinfo/system/domain_code.py
@@ -1,0 +1,8 @@
+import providers
+
+class Source(providers.DataSource):
+    def required_args(self):
+        return ['domain_code']
+
+    def call(self, domain_code):
+        return domain_code

--- a/respondd.py
+++ b/respondd.py
@@ -38,6 +38,7 @@ def get_handler(providers, batadv_ifaces, batadv_mesh_ipv4_overrides, env):
             # Clone global environment and populate with interface-specific data
             local_env = dict(env)
             local_env['batadv_dev'] = batadv_dev
+            local_env['domain_code'] = domain_code
             if batadv_dev in batadv_mesh_ipv4_overrides:
                 local_env['mesh_ipv4'] = batadv_mesh_ipv4_overrides[batadv_dev]
 
@@ -78,6 +79,9 @@ if __name__ == "__main__":
     parser.add_argument('-m', dest='mesh_ipv4',
                         metavar='<mesh_ipv4>',
                         help='mesh ipv4 address')
+    parser.add_argument('-n', dest='domain_code',
+                        metavar='domain_code',
+                        help='Domain Code for system/domain_code')
     args = parser.parse_args()
 
     # Extract batman interfaces from commandline parameters
@@ -89,6 +93,8 @@ if __name__ == "__main__":
         if mesh_ipv4:
             # mesh_ipv4 list is not empty, there is an override address
             batadv_mesh_ipv4_overrides[iface] = mesh_ipv4[0]
+
+    domain_code = args.domain_code
 
     metasocketserver.MetadataUDPServer.address_family = socket.AF_INET6
     metasocketserver.MetadataUDPServer.allow_reuse_address = True


### PR DESCRIPTION
This PR adds a provider for domain_code, which allows to display the domain of the gateway inside meshviewer etc.
Example usage: https://map.ffm.freifunk.net/#!/de/map/aaff04000802