### PR TITLE
[RFC] [RFT] Move options to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and B.A.T.M.A.N. advanced interfaces. Please *don't* open the port globally, as
 it can be used for traffic amplification attacks. You also might want to
 ratelimit it on the allowed interfaces for the same reason.
 
-#### commandline options
+#### Commandline options
 
 Those are all available options (`respondd --help`):
 
@@ -75,6 +75,9 @@ optional arguments:
   -d <dir>         data provider directory (default: $PWD/providers)
 
 ```
+
+#### Configuration
+
 Configuration is done via a ini-style config file. A possible config for a setup with a single batman domain in outlined in `respondd.conf.example`.
 The following is a more complete breakdown of the settings required:
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ MulticastSiteAddress: ff05::2:1001
 # Default domain to use
 DefaultDomain: <domain code>
 # Default domain type
-DefaultDomainType: batadv
+DomainType: batadv
 
 # A domain
 [<domain code>]
@@ -131,7 +131,7 @@ Port: 1001
 MulticastLinkAddress: ff02::2:1001
 MulticastSiteAddress: ff05::2:1001
 # Default domain type
-DefaultDomainType: batadv
+DomainType: batadv
 # IPv4 gateway option for ddhcpd
 IPv4Gateway: 10.42.0.1
 
@@ -169,7 +169,7 @@ Port: 1001
 MulticastLinkAddress: ff02::2:1001
 MulticastSiteAddress: ff05::2:1001
 # Default domain type
-DefaultDomainType: batadv
+DomainType: batadv
 
 # First domain
 [one]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,76 @@
+from configparser import ConfigParser
+
+class GlobalOptions():
+    def __init__(self, port, mcast_link, mcast_site, default_domain, default_domain_type, ipv4_gateway):
+        self.port = port
+        self.mcast_link = mcast_link
+        self.mcast_site = mcast_site
+        self.default_domain = default_domain
+        self.default_domain_type = default_domain_type
+        self.ipv4_gateway = ipv4_gateway
+
+class DomainOptions():
+    @classmethod
+    def from_parser(cls, section, parser, globals):
+        from domain import DomainType
+
+        type = parser.get(section, 'DomainType', fallback=globals.default_domain_type)
+        return DomainType.get(type).options(section, parser, globals)
+
+    def __init__(self, name, parser, globals):
+        self.name = name
+        self.vpn_iface = parser.get(name, 'VPNInterface', fallback='mvpn-' + name)
+        self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback=globals.mcast_link)
+        self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback=globals.mcast_site)
+        self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=globals.ipv4_gateway),
+
+class BatmanDomainOptions(DomainOptions):
+    def __init__(self, name, parser, globals):
+        from domain import BatadvDomain
+
+        super().__init__(name, parser, globals)
+        self.batman_iface = parser.get(name, 'BatmanInterface', fallback='bat-' + name)
+        self.domain_type = BatadvDomain
+
+class Config():
+    ''' Represents a parsed config file
+    '''
+    @classmethod
+    def from_file(cls, fname):
+        parser = ConfigParser(empty_lines_in_values=False, default_section='Defaults')
+        with open(fname) as file:
+            parser.read_file(file)
+        return cls(parser)
+
+    def __init__(self, parser):
+        self._initialize_global_options(parser)
+        self.domains = { }
+        for domain in parser.sections():
+            self._initialize_domain_options(parser, domain)
+            if not self.globals.default_domain:
+                self.globals.default_domain = self.domains[domain]
+
+    def _initialize_global_options(self, parser):
+        self.globals = GlobalOptions(
+            parser.getint(None, 'Port', fallback=1001),
+            parser.get(None, 'MulticastLinkAddress', fallback='ff02::2:1001'),
+            parser.get(None, 'MulticastSiteAddress', fallback='ff05::2:1001'),
+            parser.get(None, 'DefaultDomain', fallback=None),
+            parser.get(None, 'DefaultDomainType', fallback=None),
+            parser.get(None, 'IPv4Gateway', fallback=None),
+        )
+
+    def _initialize_domain_options(self, parser, domain):
+        self.domains[domain] = DomainOptions.from_parser(domain, parser, self.globals)
+
+    def get_domain_names(self):
+        return self.domains.keys()
+
+    def get_port(self):
+        return self.globals.port
+
+    def get_default_domain(self):
+        return self.globals.default_domain
+
+    def get_domain_config(self, domain):
+        return self.domains[domain]

--- a/config.py
+++ b/config.py
@@ -21,9 +21,9 @@ class DomainOptions():
         '''
         from domain import DomainType
 
-        type = parser.get(section, 'DomainType', fallback=globals.default_domain_type)
+        domain_type = parser.get(section, 'DomainType', fallback=globals.default_domain_type)
         # Get DomainOptions subclass for type and instantiate
-        return DomainType.get(type.lower()).options(section, parser, globals)
+        return DomainType.get(domain_type.lower()).options(section, parser, globals)
 
     def __init__(self, name, parser, globals):
         ''' Initialize common options

--- a/config.py
+++ b/config.py
@@ -19,10 +19,10 @@ class DomainOptions():
 
     def __init__(self, name, parser, globals):
         self.name = name
-        self.vpn_iface = parser.get(name, 'VPNInterface', fallback='mvpn-' + name)
+        self.interfaces = list(map(str.strip, parser.get(name, 'Interfaces', fallback='').split(',')))
         self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback=globals.mcast_link)
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback=globals.mcast_site)
-        self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=globals.ipv4_gateway),
+        self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=globals.ipv4_gateway)
 
 class BatmanDomainOptions(DomainOptions):
     def __init__(self, name, parser, globals):

--- a/config.py
+++ b/config.py
@@ -3,13 +3,9 @@ from configparser import ConfigParser
 class GlobalOptions():
     ''' Container class for global options
     '''
-    def __init__(self, port, mcast_link, mcast_site, default_domain, default_domain_type, ipv4_gateway):
+    def __init__(self, port, default_domain):
         self.port = port
-        self.mcast_link = mcast_link
-        self.mcast_site = mcast_site
         self.default_domain = default_domain
-        self.default_domain_type = default_domain_type
-        self.ipv4_gateway = ipv4_gateway
 
 class DomainOptions():
     ''' Base container class for per domain options
@@ -21,7 +17,7 @@ class DomainOptions():
         '''
         from domain import DomainType
 
-        domain_type = parser.get(section, 'DomainType', fallback=globals.default_domain_type)
+        domain_type = parser.get(section, 'DomainType', fallback='simple')
         # Get DomainOptions subclass for type and instantiate
         return DomainType.get(domain_type.lower()).options(section, parser, globals)
 
@@ -32,9 +28,9 @@ class DomainOptions():
 
         self.name = name
         self.interfaces = list(map(str.strip, parser.get(name, 'Interfaces', fallback='').split(',')))
-        self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback=globals.mcast_link)
-        self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback=globals.mcast_site)
-        self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=globals.ipv4_gateway)
+        self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback='ff02::2:1001')
+        self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback='ff05::2:1001')
+        self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=None)
         self.domain_type = Domain
 
 class BatmanDomainOptions(DomainOptions):
@@ -77,12 +73,8 @@ class Config():
         ''' Set all global options
         '''
         self.globals = GlobalOptions(
-            parser.getint(None, 'Port', fallback=1001),
-            parser.get(None, 'MulticastLinkAddress', fallback='ff02::2:1001'),
-            parser.get(None, 'MulticastSiteAddress', fallback='ff05::2:1001'),
-            parser.get(None, 'DefaultDomain', fallback=None),
-            parser.get(None, 'DefaultDomainType', fallback='simple'),
-            parser.get(None, 'IPv4Gateway', fallback=None),
+            parser.getint('Defaults', 'Port', fallback=1001),
+            parser.get('Defaults', 'DefaultDomain', fallback=None)
         )
 
     def _initialize_domain_options(self, parser, domain):

--- a/config.py
+++ b/config.py
@@ -28,11 +28,14 @@ class DomainOptions():
     def __init__(self, name, parser, globals):
         ''' Initialize common options
         '''
+        from domain import Domain
+
         self.name = name
         self.interfaces = list(map(str.strip, parser.get(name, 'Interfaces', fallback='').split(',')))
         self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback=globals.mcast_link)
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback=globals.mcast_site)
         self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=globals.ipv4_gateway)
+        self.domain_type = Domain
 
 class BatmanDomainOptions(DomainOptions):
     ''' Container for batman specific options
@@ -78,7 +81,7 @@ class Config():
             parser.get(None, 'MulticastLinkAddress', fallback='ff02::2:1001'),
             parser.get(None, 'MulticastSiteAddress', fallback='ff05::2:1001'),
             parser.get(None, 'DefaultDomain', fallback=None),
-            parser.get(None, 'DefaultDomainType', fallback=None),
+            parser.get(None, 'DefaultDomainType', fallback='simple'),
             parser.get(None, 'IPv4Gateway', fallback=None),
         )
 

--- a/domain.py
+++ b/domain.py
@@ -3,25 +3,23 @@ from config import BatmanDomainOptions
 class Domain():
     ''' Abstract container object for a freifunk domain
     '''
-    def __init__(self, mcast_link, mcast_site, ipv4_gateway):
-        self.mcast_link = mcast_link
-        self.mcast_site = mcast_site
-        self.ipv4_gateway = ipv4_gateway
+    def __init__(self, config):
+        self.config = config
 
     def get_ipv4_gateway(self):
-        return self.ipv4_gateway
+        return self.config.ipv4_gateway
 
     def get_multicast_address_link(self):
-        return self.mcast_link
+        return self.config.mcast_link
 
     def get_multicast_address_site(self):
-        return self.mcast_site
+        return self.config.mcast_site
 
     def get_interfaces(self):
         ''' Returns list off all interfaces respondd queries are
             expected to arrive on
         '''
-        return self.interfaces
+        return self.config.interfaces
 
     def get_provider_args(self):
         ''' Returns dict of parameters respondd queries are
@@ -32,16 +30,14 @@ class Domain():
 class BatadvDomain(Domain):
     ''' Container object for a batman freifunk domain
     '''
-    def __init__(self, domconfig):
-        self.batman_iface = domconfig.batman_iface
-        self.interfaces = domconfig.interfaces
-        super().__init__(domconfig.mcast_link, domconfig.mcast_site, domconfig.ipv4_gateway)
+    def __init__(self, config):
+        super().__init__(config)
 
     def get_interfaces(self):
-        return super().get_interfaces() + [self.batman_iface]
+        return super().get_interfaces() + [self.get_batman_interface()]
 
     def get_batman_interface(self):
-        return self.batman_iface
+        return self.config.batman_iface
 
     def get_provider_args(self):
         args = super().get_provider_args()

--- a/domain.py
+++ b/domain.py
@@ -1,4 +1,4 @@
-from config import BatmanDomainOptions
+from config import BatmanDomainOptions, DomainOptions
 
 class Domain():
     ''' Abstract container object for a freifunk domain

--- a/domain.py
+++ b/domain.py
@@ -24,11 +24,11 @@ class Domain():
 class BatadvDomain(Domain):
     def __init__(self, domconfig):
         self.batman_iface = domconfig.batman_iface
-        self.vpn_iface = domconfig.vpn_iface
+        self.interfaces = domconfig.interfaces
         super().__init__(domconfig.mcast_link, domconfig.mcast_site, domconfig.ipv4_gateway)
 
     def get_interfaces(self):
-        return [self.batman_iface, self.vpn_iface]
+        return [self.batman_iface] + self.interfaces
 
     def get_batman_interface(self):
         return self.batman_iface

--- a/domain.py
+++ b/domain.py
@@ -1,6 +1,8 @@
 from config import BatmanDomainOptions
 
 class Domain():
+    ''' Abstract container object for a freifunk domain
+    '''
     def __init__(self, mcast_link, mcast_site, ipv4_gateway):
         self.mcast_link = mcast_link
         self.mcast_site = mcast_site
@@ -16,19 +18,27 @@ class Domain():
         return self.mcast_site
 
     def get_interfaces(self):
-        raise NotImplementedException()
+        ''' Returns list off all interfaces respondd queries are
+            expected to arrive on
+        '''
+        return self.interfaces
 
     def get_provider_args(self):
+        ''' Returns dict of parameters respondd queries are
+            expected to arrive on
+        '''
         return { 'mesh_ipv4': self.get_ipv4_gateway() }
 
 class BatadvDomain(Domain):
+    ''' Container object for a batman freifunk domain
+    '''
     def __init__(self, domconfig):
         self.batman_iface = domconfig.batman_iface
         self.interfaces = domconfig.interfaces
         super().__init__(domconfig.mcast_link, domconfig.mcast_site, domconfig.ipv4_gateway)
 
     def get_interfaces(self):
-        return [self.batman_iface] + self.interfaces
+        return super().get_interfaces() + [self.batman_iface]
 
     def get_batman_interface(self):
         return self.batman_iface
@@ -39,6 +49,8 @@ class BatadvDomain(Domain):
         return args
 
 class DomainRegistry():
+    ''' Simple singleton based registry for freifunk domains
+    '''
     instance = None
     @classmethod
     def get_instance(cls):
@@ -60,6 +72,8 @@ class DomainRegistry():
         return None
 
     def get_interfaces(self):
+        ''' Get all domain interfaces known to this registry
+        '''
         return self.domain_by_iface.keys()
 
     def get_default_domain(self):
@@ -69,6 +83,8 @@ class DomainRegistry():
         self.default_domain = dom
 
 class DomainType():
+    ''' Domain type, links domain type to its options
+    '''
     @staticmethod
     def get(name):
         if not name in domain_types:
@@ -80,6 +96,9 @@ class DomainType():
         self.options = options
         self.domain_type = domain_type
 
+# List of domain types, key is used as domain type in config
+# Use only lower case keys, domain type from config is converted to lower
+# case during parsing
 domain_types = {
     'batadv': DomainType('batadv', BatmanDomainOptions, BatadvDomain),
 }

--- a/domain.py
+++ b/domain.py
@@ -1,0 +1,86 @@
+from config import BatmanDomainOptions
+
+class Domain():
+    def __init__(self, mcast_link, mcast_site, ipv4_gateway):
+        self.mcast_link = mcast_link
+        self.mcast_site = mcast_site
+        self.ipv4_gateway = ipv4_gateway
+
+    def get_ipv4_gateway(self):
+        return self.ipv4_gateway
+
+    def get_multicast_address_link(self):
+        return self.mcast_link
+
+    def get_multicast_address_site(self):
+        return self.mcast_site
+
+    def get_interfaces(self):
+        raise NotImplementedException()
+
+    def get_provider_args(self):
+        return { 'mesh_ipv4': self.get_ipv4_gateway() }
+
+class BatadvDomain(Domain):
+    def __init__(self, domconfig):
+        self.batman_iface = domconfig.batman_iface
+        self.vpn_iface = domconfig.vpn_iface
+        super().__init__(domconfig.mcast_link, domconfig.mcast_site, domconfig.ipv4_gateway)
+
+    def get_interfaces(self):
+        return [self.batman_iface, self.vpn_iface]
+
+    def get_batman_interface(self):
+        return self.batman_iface
+
+    def get_provider_args(self):
+        args = super().get_provider_args()
+        args.update({ 'batadv_dev': self.get_batman_interface() })
+        return args
+
+class DomainRegistry():
+    instance = None
+    @classmethod
+    def get_instance(cls):
+        if not cls.instance:
+            cls.instance = cls()
+        return cls.instance
+
+    def __init__(self):
+        self.domain_by_iface = { }
+        self.default_domain = None
+
+    def add_domain(self, dom):
+        for iface in dom.get_interfaces():
+            self.domain_by_iface[iface] = dom
+
+    def get_domain_by_interface(self, iface):
+        if iface in self.domain_by_iface:
+            return self.domain_by_iface[iface]
+        return None
+
+    def get_interfaces(self):
+        return self.domain_by_iface.keys()
+
+    def get_default_domain(self):
+        return self.default_domain
+
+    def set_default_domain(self, dom):
+        self.default_domain = dom
+
+class DomainType():
+    @staticmethod
+    def get(name):
+        if not name in domain_types:
+            raise Exception("Unknown domain type")
+        return domain_types[name]
+
+    def __init__(self, name, options, domain_type):
+        self.name = name
+        self.options = options
+        self.domain_type = domain_type
+
+domain_types = {
+    'batadv': DomainType('batadv', BatmanDomainOptions, BatadvDomain),
+}
+

--- a/domain.py
+++ b/domain.py
@@ -6,6 +6,9 @@ class Domain():
     def __init__(self, config):
         self.config = config
 
+    def get_name(self):
+        return self.config.name
+
     def get_ipv4_gateway(self):
         return self.config.ipv4_gateway
 
@@ -25,7 +28,10 @@ class Domain():
         ''' Returns dict of parameters respondd queries are
             expected to arrive on
         '''
-        return { 'mesh_ipv4': self.get_ipv4_gateway() }
+        return {
+            'domain_code': self.get_name(),
+            'mesh_ipv4': self.get_ipv4_gateway()
+        }
 
 class BatadvDomain(Domain):
     ''' Container object for a batman freifunk domain

--- a/domain.py
+++ b/domain.py
@@ -96,6 +96,7 @@ class DomainType():
 # Use only lower case keys, domain type from config is converted to lower
 # case during parsing
 domain_types = {
+    'simple': DomainType('simple', DomainOptions, Domain),
     'batadv': DomainType('batadv', BatmanDomainOptions, BatadvDomain),
 }
 

--- a/providers/nodeinfo/system/domain_code.py
+++ b/providers/nodeinfo/system/domain_code.py
@@ -2,10 +2,7 @@ import providers
 
 class Source(providers.DataSource):
     def required_args(self):
-        return ['batadv_dev', 'domain_code', 'known_codes']
+        return ['domain_code']
 
-    def call(self, batadv_dev, domain_code, known_codes):
-        try:
-            return known_codes[batadv_dev]
-        except KeyError:
-            return domain_code
+    def call(self, domain_code):
+        return domain_code

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -1,0 +1,22 @@
+# Default settings
+[Defaults]
+# Listen port
+Port: 1001
+# Default multicast listen addresses
+MulticastLinkAddress: ff02::2:1001
+MulticastSiteAddress: ff05::2:1001
+# Default domain to use
+DefaultDomain: ffki
+# Default domain type
+DefaultDomainType: batadv
+
+# A domain
+[ffki]
+# This is a batman domain
+DomainType: batadv
+# Batman interface
+BatmanInterface: bat-ffki
+# VPN interface
+VPNInterface: mvpn-ffki
+# IPv4 gateway option for ddhcpd
+IPv4Gateway: 10.116.128.8

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -1,22 +1,40 @@
 # Default settings
 [Defaults]
 # Listen port
+# optional, default: 1001
 Port: 1001
-# Default multicast listen addresses
+# Default link local listen addresses
+# optional, default: ff02::2:1001
 MulticastLinkAddress: ff02::2:1001
+# Default site local listen addresses
+# optional, default: ff05::2:1001
 MulticastSiteAddress: ff05::2:1001
 # Default domain to use
+# optional, if specified incoming requests that can not be mapped to a domain
+# are mapped to this domain
 DefaultDomain: ffki
 # Default domain type
+# optional
 DefaultDomainType: batadv
+# Default ddhcpd IPv4 gateway address
+# optional
+IPv4Gateway: 10.116.128.8
 
 # A domain
+# User your own domain name here
 [ffki]
 # This is a batman domain
+# optional, mandatory if DefaultDomainType not set, default: @DefaultDomainType
+# supported domain types are: simple, batadv
 DomainType: batadv
 # Batman interface
+# only for batadv domains, mandatory for batadv domains
 BatmanInterface: bat-ffki
 # Other listen interfaces
+# optional, specify listen/multicast interfaces for this domain here
 Interfaces: mvpn-ffki
 # IPv4 gateway option for ddhcpd
+# optional, default: @IPv4Gateway
 IPv4Gateway: 10.116.128.8
+
+# An arbitrary number of further domains may follow here

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -38,7 +38,7 @@ MulticastSiteAddress: ff05::2:1001
 # only for batadv domains, defaults to bat-<domain name>
 BatmanInterface: bat-ffki
 # Other listen interfaces
-# optional, specify listen/multicast interfaces for this domain here
+# optional, specify comma separated list of listen/multicast interfaces for this domain here
 Interfaces: mvpn-ffki
 # IPv4 gateway option for ddhcpd
 # optional, default: @IPv4Gateway

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -16,7 +16,7 @@ DefaultDomainType: batadv
 DomainType: batadv
 # Batman interface
 BatmanInterface: bat-ffki
-# VPN interface
-VPNInterface: mvpn-ffki
+# Other listen interfaces
+Interfaces: mvpn-ffki
 # IPv4 gateway option for ddhcpd
 IPv4Gateway: 10.116.128.8

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -14,7 +14,8 @@ MulticastSiteAddress: ff05::2:1001
 # are mapped to this domain
 DefaultDomain: ffki
 # Default domain type
-# optional
+# optional, default: simple
+# supported domain types are: simple, batadv
 DomainType: batadv
 # Default ddhcpd IPv4 gateway address
 # optional
@@ -24,11 +25,17 @@ IPv4Gateway: 10.116.128.8
 # User your own domain name here
 [ffki]
 # This is a batman domain
-# optional, mandatory if DomainType not set, default: @DomainType
+# optional, default: @Defaults.DomainType
 # supported domain types are: simple, batadv
 DomainType: batadv
+# Link local listen addresses
+# optional, default: @Defaults.MulticastLinkAddress
+MulticastLinkAddress: ff02::2:1001
+# Site local listen addresses
+# optional, default: @Defautls.MulticastSiteAddress
+MulticastSiteAddress: ff05::2:1001
 # Batman interface
-# only for batadv domains, mandatory for batadv domains
+# only for batadv domains, defaults to bat-<domain name>
 BatmanInterface: bat-ffki
 # Other listen interfaces
 # optional, specify listen/multicast interfaces for this domain here

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -15,7 +15,7 @@ MulticastSiteAddress: ff05::2:1001
 DefaultDomain: ffki
 # Default domain type
 # optional
-DefaultDomainType: batadv
+DomainType: batadv
 # Default ddhcpd IPv4 gateway address
 # optional
 IPv4Gateway: 10.116.128.8
@@ -24,7 +24,7 @@ IPv4Gateway: 10.116.128.8
 # User your own domain name here
 [ffki]
 # This is a batman domain
-# optional, mandatory if DefaultDomainType not set, default: @DefaultDomainType
+# optional, mandatory if DomainType not set, default: @DomainType
 # supported domain types are: simple, batadv
 DomainType: batadv
 # Batman interface

--- a/respondd.py
+++ b/respondd.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
       %(prog)s [-f <configfile>] [-d <dir>]""")
     parser.add_argument('-f', dest='config',
                         default='./respondd.conf', metavar='<configfile>',
-                        help='config file to use')
+                        help='config file to use (default: $PWD/respondd.conf)')
     parser.add_argument('-d', dest='directory',
                         default='./providers', metavar='<dir>',
                         help='data provider directory (default: $PWD/providers)')

--- a/respondd.py
+++ b/respondd.py
@@ -36,7 +36,10 @@ def get_handler(providers):
 
             domain = DomainRegistry.get_instance().get_domain_by_interface(iface)
             if not domain:
-                return
+                # Try default domain, ignore request if not configured
+                domain = DomainRegistry.get_instance().get_default_domain()
+                if not domain:
+                    return
 
             provider_env = domain.get_provider_args()
 
@@ -68,8 +71,10 @@ if __name__ == "__main__":
     config = Config.from_file(args.config)
     for domname in config.get_domain_names():
         domcfg = config.get_domain_config(domname)
-        DomainRegistry.get_instance().add_domain(domcfg.domain_type(domcfg))
-    DomainRegistry.get_instance().set_default_domain
+        domain = domcfg.domain_type(domcfg)
+        DomainRegistry.get_instance().add_domain(domain)
+        if domname == config.get_default_domain():
+            DomainRegistry.get_instance().set_default_domain(domain)
 
     metasocketserver.MetadataUDPServer.address_family = socket.AF_INET6
     metasocketserver.MetadataUDPServer.allow_reuse_address = True

--- a/util.py
+++ b/util.py
@@ -35,7 +35,6 @@ def ifindex_to_iface(if_index):
             return iface
     return None
 
-
 def iface_match_recursive(iface, candidates):
     """Check if iface has any connection with an interface from candidates
        through master/slave relationship and return the name of the first
@@ -73,17 +72,3 @@ def ifindex_to_batiface(if_index, batman_ifaces):
     if iface in batman_ifaces or iface == None:
         return iface
     return iface_match_recursive(iface, batman_ifaces)
-
-def read_domainfile(dcf_path):
-    """Read a json file which holds all currently known assignments of
-       bat interfaces to domains as a dictionary within a dict and below its key 'domaincodes'
-       and return it as python dict.
-       Return an empty dict, if the given path was None.
-    """
-    if dcf_path is None:
-        return {}
-    with open(dcf_path, "r") as dc_file:
-        try:
-            return json.load(dc_file)["domaincodes"]
-        except KeyError:
-            return {}


### PR DESCRIPTION
This PR moves the configuration of mesh-announce to a config file. The old commandline based config interface is a hot mess.

Currently this is a breaking change. The old command line options have been removed and replaced by a config file. 

@AiyionPrime @mweinelt what are your thoughts on this change? Do you agree with the overall config concept?