### PR TITLE
Replace deprecated batctl parameter

### DIFF
--- a/providers/neighbours/batadv.py
+++ b/providers/neighbours/batadv.py
@@ -8,7 +8,7 @@ class Source(providers.DataSource):
         return ['batadv_dev']
 
     def call(self, batadv_dev):
-        lines = call(['batctl', '-m', batadv_dev, 'o', '-nH'])
+        lines = call(['batctl', 'meshif', batadv_dev, 'o', '-nH'])
         neighbours = {}
         prefix_lower = '/sys/class/net/{}/lower_'.format(batadv_dev)
         for dev in glob(prefix_lower + '*'):

--- a/providers/nodeinfo/network/mesh.py
+++ b/providers/nodeinfo/network/mesh.py
@@ -13,7 +13,7 @@ class Source(providers.DataSource):
                         open('/sys/class/net/{}/address'.format(iface)).read().strip()
                         for iface in map(
                             lambda line: line.split(':')[0],
-                            call(['batctl', '-m', batadv_dev, 'if'])
+                            call(['batctl', 'meshif', batadv_dev, 'if'])
                         )
                     ]
                 }


### PR DESCRIPTION
This commit will get rid of the warning messages @margau found in PR https://github.com/ffnord/mesh-announce/pull/51#issuecomment-572641823

The referenced mail contains the original commit, where `-m` got deprecated.
This should be rather quick to fix.

closes #50

My related commit message:

> batctls syntax is changing and deprecated the usage of -m
> and suggests 'meshif' as drop in replacement.
> 
> https://lists.open-mesh.org/mailman3/hyperkitty/list/b.a.t.m.a.n@lists.open-mesh.org/thread/AHRNDJTW3HNU5NQ5MVI6WZEZZ32PBHZT/