### PR TITLE
Add vpn public-key support for fastd

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,6 +38,7 @@ class DomainOptions():
         self.latitude = parser.getfloat(name, 'Latitude', fallback=None)
         self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback='ff02::2:1001')
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback='ff05::2:1001')
+        self.vpn_pubkey = parser.get(name, 'FastdPublicKey', fallback=None)
         self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=None)
         self.domain_type = Domain
 

--- a/domain.py
+++ b/domain.py
@@ -35,6 +35,8 @@ class Domain():
 
     def is_gateway(self):
         return self.config.is_gateway
+    def get_vpn_pubkey(self):
+        return self.config.vpn_pubkey
 
     def get_interfaces(self):
         ''' Returns list off all interfaces respondd queries are
@@ -54,7 +56,8 @@ class Domain():
             'is_gateway': self.is_gateway(),
             'latitude': self.get_latitude(),
             'longitude': self.get_longitude(),
-            'mesh_ipv4': self.get_ipv4_gateway()
+            'mesh_ipv4': self.get_ipv4_gateway(),
+            'vpn_pubkey': self.get_vpn_pubkey()
         }
 
 class BatadvDomain(Domain):

--- a/providers/nodeinfo/software/fastd/public_key.py
+++ b/providers/nodeinfo/software/fastd/public_key.py
@@ -1,0 +1,9 @@
+import providers
+
+
+class Source(providers.DataSource):
+    def call(self, vpn_pubkey):
+        return vpn_pubkey
+
+    def required_args(self):
+        return ['vpn_pubkey']

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -17,6 +17,9 @@ DefaultDomain: ffki
 # optional, default: simple
 # supported domain types are: simple, batadv
 DomainType: batadv
+# Default fastd-public-key to use
+# optional, default is None
+# FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
 # Default ddhcpd IPv4 gateway address
 # optional
 IPv4Gateway: 10.116.128.8
@@ -46,6 +49,9 @@ VPN: True
 # optional, default: @Defaults.DomainType
 # supported domain types are: simple, batadv
 DomainType: batadv
+# Default fastd-public-key to use
+# optional, default: @FastdPublickey
+# FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
 # Link local listen addresses
 # optional, default: @Defaults.MulticastLinkAddress
 MulticastLinkAddress: ff02::2:1001


### PR DESCRIPTION
This implements the missing key for fastd-servers on domain level, like supported by gluon.

Tested on one of our supernodes.

closes #68