### PR TITLE
Implement an option to specify VPNProtocols

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class DomainOptions():
         self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback='ff02::2:1001')
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback='ff05::2:1001')
         self.vpn_pubkey = parser.get(name, 'FastdPublicKey', fallback=None)
-        self.vpn_proto = parser.get(name, 'VPNProtocol', fallback='fastd')
+        self.vpn_protos = frozenset(parser.get(name, 'VPNProtocols', fallback='fastd').split(','))
         self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=None)
         self.domain_code = parser.get(name, 'DomainCode', fallback=name)
         self.domain_type = Domain

--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ class DomainOptions():
         self.mcast_link = parser.get(name, 'MulticastLinkAddress', fallback='ff02::2:1001')
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback='ff05::2:1001')
         self.vpn_pubkey = parser.get(name, 'FastdPublicKey', fallback=None)
+        self.vpn_proto = parser.get(name, 'VPNProtocol', fallback='fastd')
         self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=None)
         self.domain_code = parser.get(name, 'DomainCode', fallback=name)
         self.domain_type = Domain

--- a/domain.py
+++ b/domain.py
@@ -38,8 +38,12 @@ class Domain():
 
     def is_gateway(self):
         return self.config.is_gateway
+
     def get_vpn_pubkey(self):
         return self.config.vpn_pubkey
+
+    def get_vpn_proto(self):
+        return self.config.vpn_proto
 
     def get_interfaces(self):
         ''' Returns list off all interfaces respondd queries are
@@ -61,7 +65,8 @@ class Domain():
             'latitude': self.get_latitude(),
             'longitude': self.get_longitude(),
             'mesh_ipv4': self.get_ipv4_gateway(),
-            'vpn_pubkey': self.get_vpn_pubkey()
+            'vpn_pubkey': self.get_vpn_pubkey(),
+            'vpn_proto': self.get_vpn_proto()
         }
 
 class BatadvDomain(Domain):

--- a/domain.py
+++ b/domain.py
@@ -42,8 +42,8 @@ class Domain():
     def get_vpn_pubkey(self):
         return self.config.vpn_pubkey
 
-    def get_vpn_proto(self):
-        return self.config.vpn_proto
+    def get_vpn_protos(self):
+        return self.config.vpn_protos
 
     def get_interfaces(self):
         ''' Returns list off all interfaces respondd queries are
@@ -66,7 +66,7 @@ class Domain():
             'longitude': self.get_longitude(),
             'mesh_ipv4': self.get_ipv4_gateway(),
             'vpn_pubkey': self.get_vpn_pubkey(),
-            'vpn_proto': self.get_vpn_proto()
+            'vpn_protos': self.get_vpn_protos()
         }
 
 class BatadvDomain(Domain):

--- a/providers/nodeinfo/software/fastd/enabled.py
+++ b/providers/nodeinfo/software/fastd/enabled.py
@@ -2,9 +2,14 @@ import providers
 from util import check_process_running
 
 
+
 class Source(providers.DataSource):
-    def call(self):
-        try:
-            return check_process_running('fastd')
-        except ImportError:
-            return True
+    def call(self, vpn_proto):
+        if 'fastd' == vpn_proto:
+            try:
+                return check_process_running('fastd')
+            except ImportError:
+                return True
+
+    def required_args(self):
+        return ['vpn_proto']

--- a/providers/nodeinfo/software/fastd/enabled.py
+++ b/providers/nodeinfo/software/fastd/enabled.py
@@ -4,12 +4,12 @@ from util import check_process_running
 
 
 class Source(providers.DataSource):
-    def call(self, vpn_proto):
-        if 'fastd' == vpn_proto:
+    def call(self, vpn_protos):
+        if 'fastd' in vpn_protos:
             try:
                 return check_process_running('fastd')
             except ImportError:
                 return True
 
     def required_args(self):
-        return ['vpn_proto']
+        return ['vpn_protos']

--- a/providers/nodeinfo/software/fastd/public_key.py
+++ b/providers/nodeinfo/software/fastd/public_key.py
@@ -2,8 +2,9 @@ import providers
 
 
 class Source(providers.DataSource):
-    def call(self, vpn_pubkey):
-        return vpn_pubkey
+    def call(self, vpn_proto, vpn_pubkey):
+        if 'fastd' == vpn_proto:
+            return vpn_pubkey
 
     def required_args(self):
-        return ['vpn_pubkey']
+        return ['vpn_proto', 'vpn_pubkey']

--- a/providers/nodeinfo/software/fastd/public_key.py
+++ b/providers/nodeinfo/software/fastd/public_key.py
@@ -2,9 +2,9 @@ import providers
 
 
 class Source(providers.DataSource):
-    def call(self, vpn_proto, vpn_pubkey):
-        if 'fastd' == vpn_proto:
+    def call(self, vpn_protos, vpn_pubkey):
+        if 'fastd' in vpn_protos:
             return vpn_pubkey
 
     def required_args(self):
-        return ['vpn_proto', 'vpn_pubkey']
+        return ['vpn_protos', 'vpn_pubkey']

--- a/providers/nodeinfo/software/fastd/version.py
+++ b/providers/nodeinfo/software/fastd/version.py
@@ -1,6 +1,11 @@
 import providers
 from providers.util import call
 
+
 class Source(providers.DataSource):
-    def call(self):
-        return call(['fastd','-v'])[0].split(' ')[1]
+    def call(self, vpn_proto):
+        if 'fastd' == vpn_proto:
+            return call(['fastd', '-v'])[0].split(' ')[1]
+
+    def required_args(self):
+        return ['vpn_proto']

--- a/providers/nodeinfo/software/fastd/version.py
+++ b/providers/nodeinfo/software/fastd/version.py
@@ -3,9 +3,9 @@ from providers.util import call
 
 
 class Source(providers.DataSource):
-    def call(self, vpn_proto):
-        if 'fastd' == vpn_proto:
+    def call(self, vpn_protos):
+        if 'fastd' in vpn_protos:
             return call(['fastd', '-v'])[0].split(' ')[1]
 
     def required_args(self):
-        return ['vpn_proto']
+        return ['vpn_protos']

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -20,10 +20,11 @@ DomainType: batadv
 # Default fastd-public-key to use
 # optional, default is None
 # FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
-# Default vpn protocol to use
+# Default vpn protocols to use
+# may contain csv if more than one protocol is used
 # optional, default is fastd
 # supported protocols are: fastd, None
-VPNProtocol: fastd
+VPNProtocols: fastd
 # Default ddhcpd IPv4 gateway address
 # optional
 IPv4Gateway: 10.116.128.8
@@ -61,10 +62,11 @@ DomainType: batadv
 # Default fastd-public-key to use
 # optional, default: @FastdPublickey
 # FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
-# Default vpn protocol to use
+# Default vpn protocols to use
+# may contain csv if more than one protocol is used
 # optional, default is @VPNProtocol
 # supported protocols are: fastd, None
-VPNProtocol: fastd
+VPNProtocols: fastd
 # Link local listen addresses
 # optional, default: @Defaults.MulticastLinkAddress
 MulticastLinkAddress: ff02::2:1001

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -20,6 +20,10 @@ DomainType: batadv
 # Default fastd-public-key to use
 # optional, default is None
 # FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
+# Default vpn protocol to use
+# optional, default is fastd
+# supported protocols are: fastd, None
+VPNProtocol: fastd
 # Default ddhcpd IPv4 gateway address
 # optional
 IPv4Gateway: 10.116.128.8
@@ -57,6 +61,10 @@ DomainType: batadv
 # Default fastd-public-key to use
 # optional, default: @FastdPublickey
 # FastdPublicKey: 0000000000000000000000000000000000000000000000000000000000000000
+# Default vpn protocol to use
+# optional, default is @VPNProtocol
+# supported protocols are: fastd, None
+VPNProtocol: fastd
 # Link local listen addresses
 # optional, default: @Defaults.MulticastLinkAddress
 MulticastLinkAddress: ff02::2:1001


### PR DESCRIPTION
This gets rid of fastd for those who don't want it anymore, while letting it be as the default for any current users.


> 'fastd' is the only valid option, for now,
> anything else results in fastd hidden
> under software and not called for its version,
> therefore this resolves #66

