### PR TITLE
Emit primary_domain_code

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ class DomainOptions():
         self.mcast_site = parser.get(name, 'MulticastSiteAddress', fallback='ff05::2:1001')
         self.vpn_pubkey = parser.get(name, 'FastdPublicKey', fallback=None)
         self.ipv4_gateway = parser.get(name, 'IPv4Gateway', fallback=None)
+        self.domain_code = parser.get(name, 'DomainCode', fallback=name)
         self.domain_type = Domain
 
 class BatmanDomainOptions(DomainOptions):

--- a/domain.py
+++ b/domain.py
@@ -9,6 +9,9 @@ class Domain():
     def get_contact(self):
         return self.config.contact
 
+    def get_domain_code(self):
+        return self.config.domain_code
+
     def get_name(self):
         return self.config.name
 
@@ -50,7 +53,8 @@ class Domain():
         '''
         return {
             'contact': self.get_contact(),
-            'domain_code': self.get_name(),
+            'domain_code': self.get_domain_code(),
+            'primary_domain_code': self.get_name(),
             'hardware_model': self.get_hardware_model(),
             'hostname': self.get_hostname(),
             'is_gateway': self.is_gateway(),

--- a/providers/nodeinfo/system/primary_domain_code.py
+++ b/providers/nodeinfo/system/primary_domain_code.py
@@ -1,0 +1,8 @@
+import providers
+
+class Source(providers.DataSource):
+    def required_args(self):
+        return ['primary_domain_code']
+
+    def call(self, primary_domain_code):
+        return primary_domain_code

--- a/respondd.conf.example
+++ b/respondd.conf.example
@@ -45,6 +45,11 @@ VPN: True
 # A domain
 # User your own domain name here
 [ffki]
+# overwrite for domain_code
+# optional: If specified, domain_code emits this instead of primary_domain_code,
+# which is taken from the section title
+# default: section title
+DomainCode: kiel_gaarden
 # This is a batman domain
 # optional, default: @Defaults.DomainType
 # supported domain types are: simple, batadv


### PR DESCRIPTION
This PR intends to resolve #61 and  introduces two non-breaking changes.

1. emit what was `domain_code` before, as `primary_domain_code` as well.
2. optionally overwrite `domain_code` with a configured value (`DomainCode`) in order to allow the specification of a domain alias.

This is a feature of gluon since v2020.2.
https://gluon.readthedocs.io/en/latest/releases/v2020.2.html#primary-domain-code