### PR TITLE
fix null values for unconfigured vpn-providers

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -27,7 +27,9 @@ class DataSource():
     def is_enabled(self, env):
         ''' Override when special preconditions for calling exist
         '''
-        has_args = map(lambda arg: arg in env and env[arg] != None, self.required_args())
+        has_args = map(lambda arg: arg.split(":")[0] in env and \
+            ":" not in arg and env[arg] != None or \
+            ":" in arg and all(value in env[arg.split(":")[0]] for value in arg.split(":")[1:]), self.required_args())
         return reduce(bool.__and__, has_args, True)
 
 
@@ -105,7 +107,8 @@ class Source():
         cache = SourceCache.getinstance()
 
         args = []
-        for argname in self.source.required_args():
+        for fullarg in self.source.required_args():
+            argname = fullarg.split(":")[0]
             args.append(env[argname])
 
         cache_result = cache.get(frozenset([self] + args))

--- a/providers/nodeinfo/software/fastd/enabled.py
+++ b/providers/nodeinfo/software/fastd/enabled.py
@@ -11,4 +11,4 @@ class Source(providers.DataSource):
                 return True
 
     def required_args(self):
-        return ['vpn_protos']
+        return ['vpn_protos:fastd']

--- a/providers/nodeinfo/software/fastd/public_key.py
+++ b/providers/nodeinfo/software/fastd/public_key.py
@@ -7,4 +7,4 @@ class Source(providers.DataSource):
             return fastd_pubkey
 
     def required_args(self):
-        return ['vpn_protos', 'fastd_pubkey']
+        return ['vpn_protos:fastd', 'fastd_pubkey']

--- a/providers/nodeinfo/software/fastd/version.py
+++ b/providers/nodeinfo/software/fastd/version.py
@@ -8,4 +8,4 @@ class Source(providers.DataSource):
             return call(['fastd', '-v'])[0].split(' ')[1]
 
     def required_args(self):
-        return ['vpn_protos']
+        return ['vpn_protos:fastd']

--- a/providers/nodeinfo/software/wireguard/enabled.py
+++ b/providers/nodeinfo/software/wireguard/enabled.py
@@ -8,4 +8,4 @@ class Source(providers.DataSource):
             return exists("/sys/module/wireguard/initstate")
 
     def required_args(self):
-        return ['vpn_protos']
+        return ['vpn_protos:wireguard']

--- a/providers/nodeinfo/software/wireguard/public_key.py
+++ b/providers/nodeinfo/software/wireguard/public_key.py
@@ -7,4 +7,4 @@ class Source(providers.DataSource):
             return wireguard_pubkey
 
     def required_args(self):
-        return ['vpn_protos', 'wireguard_pubkey']
+        return ['vpn_protos:wireguard', 'wireguard_pubkey']

--- a/providers/nodeinfo/software/wireguard/version.py
+++ b/providers/nodeinfo/software/wireguard/version.py
@@ -7,4 +7,4 @@ class Source(providers.DataSource):
             return open('/sys/module/wireguard/version').read().strip()
 
     def required_args(self):
-        return ['vpn_protos']
+        return ['vpn_protos:wireguard']


### PR DESCRIPTION
resolves #83 

This is ~~not yet tested at all, but~~ a mere draft on what syntax I'd prefer.

Using the colon as a seperator mirrors the colon in dicts.
The changes in the `__ini__.py` use everything before the first colon as key and treat everything after that as values.
values must all be in the keys configured values.

`tibet` is a regular key as before, it must exist and its assigned value must not be `None`.

`tibet:lama` wants tibet to exist like before, but the assigned value must contain `lama`.

`tibet:dalai:lama` wants tibet to exist like before, but requires both values `dalai` and `lama` to be configured in `tibet`.

A Config line that fulfils the last requirement:


`tibet = dalai,lama`

another one:

`tibet = lama,dalai`

and a negative example:

`tibet = unrelated,lama`

Sidenote: all three config-lines above fulfil `tibet:lama`.